### PR TITLE
Reduce train reg

### DIFF
--- a/classifiers.py
+++ b/classifiers.py
@@ -5,8 +5,9 @@ from sklearn.model_selection import train_test_split
 import torch
 from constr_KMeans import ConKMeans
 import utils
-
-def regression(data_dict, emb_name, per_train=.3):
+import warnings
+from sklearn.exceptions import ConvergenceWarning
+def regression(data_dict, emb_name, per_train=1):
      #multiclass solver, the one guillaume recommended
     solver = 'saga'
     #80/20 train test
@@ -26,7 +27,6 @@ def regression(data_dict, emb_name, per_train=.3):
         X_test = data_dict[name]['X_test']
         Y_test = data_dict[name]['Y_test']
         #This is horribly inefficient, but we cannot randomly split
-        print(len(labels))
         if per_train < 1:
             new_df = pd.DataFrame({"index":range(len(X_train)), "sem_label":Y_train})
             new_train, _ = utils.custom_train_test_split(new_df, train_split=per_train) 
@@ -43,7 +43,9 @@ def regression(data_dict, emb_name, per_train=.3):
             #cross_validation, need to make sure equal senses in training data
         else: 
                 #need to ensure equal distribution of labels
-            classifier.fit(X_train, Y_train)
+            with warnings.catch_warnings():
+                warnings.filterwarnings("ignore", category=ConvergenceWarning)
+                classifier.fit(X_train, Y_train)
             pred = classifier.predict(X_test)
             app_df = pd.DataFrame({
             "pred":pred,

--- a/classifiers.py
+++ b/classifiers.py
@@ -6,11 +6,10 @@ import torch
 from constr_KMeans import ConKMeans
 import utils
 
-def regression(data_dict, emb_name):
+def regression(data_dict, emb_name, per_train=.3):
      #multiclass solver, the one guillaume recommended
     solver = 'saga'
     #80/20 train test
-    split = .8
     #group by lemma
     preds = pd.DataFrame({"pred":list(), "gold":list(), "lemma":list()})
     lemma_most_com = dict()
@@ -26,7 +25,14 @@ def regression(data_dict, emb_name):
         Y_train = data_dict[name]['Y_train']
         X_test = data_dict[name]['X_test']
         Y_test = data_dict[name]['Y_test']
-
+        #This is horribly inefficient, but we cannot randomly split
+        print(len(labels))
+        if per_train < 1:
+            new_df = pd.DataFrame({"index":range(len(X_train)), "sem_label":Y_train})
+            new_train, _ = utils.custom_train_test_split(new_df, train_split=per_train) 
+            new_train_indices = list(new_train['index'])
+            X_train = X_train[new_train_indices]
+            Y_train = Y_train[new_train_indices]
         if (len(labels) == 1):
             app_df = pd.DataFrame({
                 "pred":[list(labels)[0]]*len(X_test),

--- a/collect_data.py
+++ b/collect_data.py
@@ -17,9 +17,9 @@ def main(xml_path, gold_path, embeddings):
 
     df['bert'] = load(xml_path + 'bert.npy', allow_pickle=True)
     print("Fasttext embeddings")
-    df['fasttext'] = ws_embeddings.fasttext_emb(df)
+    #df['fasttext'] = ws_embeddings.fasttext_emb(df)
 
-    #df['fasttext'] = load(xml_path + 'ft.npy', allow_pickle=True)
+    df['fasttext'] = load(xml_path + 'ft.npy', allow_pickle=True)
     data_dict = data.prepare_data(df, embeddings)
     regression_dict = dict()
     clustering_dict = dict()
@@ -27,7 +27,9 @@ def main(xml_path, gold_path, embeddings):
     for embed in embeddings:
         print("\n" + embed + "\n----")
         print("--regression")
-        regression_dict[embed + '_regression'] = classifiers.regression(data_dict, embed)
+        for reduction in [1.0, .75, .50, .40, .30]:
+            print(reduction)
+            regression_dict[embed + '_regression_' + str(int(reduction*100))] = classifiers.regression(data_dict, embed, per_train=reduction)
         print("--base-cl-cos")
         clustering_dict[embed + '_base-clustering-cos'] = classifiers.base_clustering(data_dict, emb_name=embed, m_m=np.argmax, sim_metric=utils.cl_cossim) 
         print("--const-cl-cos")

--- a/utils.py
+++ b/utils.py
@@ -3,23 +3,21 @@ from sklearn.utils import resample
 import sklearn.metrics as sklm
 import pandas as pd
 import numpy as np
-def custom_train_test_split(df):
+def custom_train_test_split(df, train_split=.8):
   # Get the value counts of 'sem_label'
   label_counts = df['sem_label'].value_counts()
-
   # Identify labels with only one example
   single_example_labels = label_counts[label_counts == 1].index.tolist()
 
   # Filter the DataFrame to get rows with single examples
   rows_to_duplicate = df[df['sem_label'].isin(single_example_labels)]
-
   # Duplicate these rows
   duplicated_rows = pd.concat([rows_to_duplicate] * 1, ignore_index=True) # Duplicate once
 
   # Concatenate the original DataFrame with the duplicated rows
   df = pd.concat([df, duplicated_rows], ignore_index=True)
 
-  train, test = train_test_split(df,test_size=0.2, stratify=df['sem_label'])#, random_state=42)
+  train, test = train_test_split(df,test_size=1-train_split, stratify=df['sem_label'])#, random_state=42)
 
   return train, test
 


### PR DESCRIPTION
Added options to reduce training size while 
  1: Keeping data balanced
  2: Keeping the test set the same

At around <30% of training set some  lemmas break (as this is smaller than the number of classes i.e .3 * 10 < 4, and there are 4 classes for that lemma.

At >80% of training set the split breaks for the same reason, but in the test test.

This is all a byproduct of our custom_train_test_split method, but I think that the values .75, .5, .4, .3, are both useful and aesthetically pleasing.